### PR TITLE
Allow multiple valid webhook URL FQDNs

### DIFF
--- a/send.go
+++ b/send.go
@@ -82,9 +82,11 @@ func isValidWebhookURL(webhookURL string) (bool, error) {
 		return false, err
 	}
 	// only pass MS teams webhook URLs
-	hasPrefix := strings.HasPrefix(webhookURL, "https://outlook.office.com/webhook/")
-	if !hasPrefix {
-		err = errors.New("unvalid ms teams webhook url")
+	switch {
+	case strings.HasPrefix(webhookURL, "https://outlook.office.com/webhook/"):
+	case strings.HasPrefix(webhookURL, "https://outlook.office365.com/webhook/"):
+	default:
+		err = errors.New("invalid ms teams webhook url")
 		return false, err
 	}
 	return true, nil

--- a/send_test.go
+++ b/send_test.go
@@ -33,7 +33,7 @@ func TestTeamsClientSend(t *testing.T) {
 			resError:  nil,
 			error:     &url.Error{},
 		},
-		// invalid webhookURL - missing pefix in (https://outlook.office.com...) URL
+		// invalid webhookURL - missing prefix in webhook URL
 		{
 			reqURL:    "",
 			reqMsg:    emptyMessage,
@@ -49,6 +49,14 @@ func TestTeamsClientSend(t *testing.T) {
 			resError:  errors.New("pling"),
 			error:     &url.Error{},
 		},
+		// invalid httpClient.Do call
+		{
+			reqURL:    "https://outlook.office365.com/webhook/xxx",
+			reqMsg:    emptyMessage,
+			resStatus: 200,
+			resError:  errors.New("pling"),
+			error:     &url.Error{},
+		},
 		// invalid response status code
 		{
 			reqURL:    "https://outlook.office.com/webhook/xxx",
@@ -57,9 +65,25 @@ func TestTeamsClientSend(t *testing.T) {
 			resError:  nil,
 			error:     errors.New(""),
 		},
+		// invalid response status code
+		{
+			reqURL:    "https://outlook.office365.com/webhook/xxx",
+			reqMsg:    emptyMessage,
+			resStatus: 400,
+			resError:  nil,
+			error:     errors.New(""),
+		},
 		// valid
 		{
 			reqURL:    "https://outlook.office.com/webhook/xxx",
+			reqMsg:    emptyMessage,
+			resStatus: 200,
+			resError:  nil,
+			error:     nil,
+		},
+		// valid
+		{
+			reqURL:    "https://outlook.office365.com/webhook/xxx",
 			reqMsg:    emptyMessage,
 			resStatus: 200,
 			resError:  nil,


### PR DESCRIPTION
## Changes

Based on research/testing, it appears that both of these two FQDNs are interchangeable:

- outlook.office.com
- outlook.office365.com

This commit makes the following changes to accept either FQDN as a valid webhook prefix:

- update the `isValidWebhookURL` validation function to accept either one as a valid webhook prefix
- update the `TestTeamsClientSend` table test to include outlook.office365.com variations of existing test cases specific to outlook.office.com

## References

- fixes dasrick/go-teams-notify#3

- https://docs.microsoft.com/en-us/outlook/actionable-messages/send-via-connectors#get-a-connector-webhook-url-for-your-inbox
  - see the example URL listed on that page
    - https://outlook.office365.com/webhook/a1269812-6d10-44b1-abc5-b84f93580ba0@9e7b80c7-d1eb-4b52-8582-76f921e416d9/IncomingWebhook/3fdd6767bae44ac58e5995547d66a4e4/f332c8d9-3397-4ac5-957b-b8e3fc465a8c