### PR TITLE
scopelint: Fix improper range loop var reference

### DIFF
--- a/messagecard.go
+++ b/messagecard.go
@@ -229,16 +229,16 @@ func (mcs *MessageCardSection) AddFactFromKeyValue(key string, values ...string)
 // AddImage adds an image to a MessageCard section. These images are used to
 // provide a photo gallery inside a MessageCard section.
 func (mcs *MessageCardSection) AddImage(sectionImage ...MessageCardSectionImage) error {
-	for _, img := range sectionImage {
-		if img.Image == "" {
+	for i := range sectionImage {
+		if sectionImage[i].Image == "" {
 			return fmt.Errorf("cannot add empty image URL")
 		}
 
-		if img.Title == "" {
+		if sectionImage[i].Title == "" {
 			return fmt.Errorf("cannot add empty image title")
 		}
 
-		mcs.Images = append(mcs.Images, &img) // nolint:scopelint
+		mcs.Images = append(mcs.Images, &sectionImage[i])
 	}
 
 	return nil


### PR DESCRIPTION
## Problem

Error from `scopelint` linter:

"Using a reference for the variable on range scope `img`"

## Resolution

Use index from range loop to *reach into* the slice argument to retrieve the address of those values instead of using the range loop variable, which likely would have been a subtle source of bugs later on.

## References

- #6
- #11
- #12