### PR TITLE
Add missing Facts assignment in MessageCardSection

### DIFF
--- a/messagecard.go
+++ b/messagecard.go
@@ -195,6 +195,8 @@ func (mcs *MessageCardSection) AddFact(fact ...MessageCardSectionFact) error {
 		}
 	}
 
+	mcs.Facts = append(mcs.Facts, fact...)
+
 	return nil
 }
 


### PR DESCRIPTION
This was intended to go in with the other work for dasrick/go-teams-notify#6, but I think this assignment statement was unintentionally trimmed alongside the removal of the package-level logger statements referenced in dasrick/go-teams-notify#10.

I caught this when performing a test rebase to audit what remaining changes in my fork haven't been included or proposed in the parent/upstream project.