### PR TITLE
Fix whitespace linting error

### DIFF
--- a/send.go
+++ b/send.go
@@ -86,7 +86,6 @@ func IsValidInput(webhookMessage MessageCard, webhookURL string) (bool, error) {
 // IsValidWebhookURL performs validation checks on the webhook URL used to
 // submit messages to Microsoft Teams.
 func IsValidWebhookURL(webhookURL string) (bool, error) {
-
 	switch {
 	case strings.HasPrefix(webhookURL, WebhookURLOfficecomPrefix):
 	case strings.HasPrefix(webhookURL, WebhookURLOffice365Prefix):


### PR DESCRIPTION
Fix this golangci-lint linting error introduced in #11:

`send.go:88: unnecessary leading newline (whitespace)`