### PR TITLE
Fix AddFact to actually adding a fact

### DIFF
--- a/messagecard.go
+++ b/messagecard.go
@@ -193,6 +193,7 @@ func (mcs *MessageCardSection) AddFact(fact ...MessageCardSectionFact) error {
 		if f.Value == "" {
 			return fmt.Errorf("empty Name field received for new fact: %+v", f)
 		}
+		mcs.Facts = append(mcs.Facts, f)
 	}
 
 	return nil


### PR DESCRIPTION
The MessageCardSection.AddFact method doesn't actually add the given Facts. This is a simple change to make that work.